### PR TITLE
chore: Add custom logging to SynapseMLLogger

### DIFF
--- a/core/src/main/python/synapse/ml/core/logging/SynapseMLLogger.py
+++ b/core/src/main/python/synapse/ml/core/logging/SynapseMLLogger.py
@@ -11,7 +11,6 @@ from pyspark.sql.dataframe import DataFrame
 from pyspark import SparkContext
 from pyspark.sql import SparkSession
 import json
-import inspect
 
 PROTOCOL_VERSION = "0.0.1"
 

--- a/core/src/test/python/synapsemltest/core/test_logging.py
+++ b/core/src/test/python/synapsemltest/core/test_logging.py
@@ -50,13 +50,26 @@ class NoInheritTransformer():
     def test_throw(self):
         raise Exception("test exception")
 
+    @SynapseMLLogger.log_verb_static(feature_name="test_logging")
+    def test_feature_name(self):
+        return 0
+
     def custom_logging_function(self, results, *args, **kwargs):
         return {"args": f"Arguments: {args}",
                 "result": str(results)}
 
     @SynapseMLLogger.log_verb_static(custom_log_function=custom_logging_function)
     def test_custom_function(self, df):
-        return 42
+        return 0
+
+    def custom_logging_function_w_collision(self, results, *args, **kwargs):
+        return {"args": f"Arguments: {args}",
+                "result": str(results),
+                "className": "this is the collision key"}
+
+    @SynapseMLLogger.log_verb_static(custom_log_function=custom_logging_function_w_collision)
+    def test_custom_function_w_collision(self, df):
+        return 0
 
 
 class LoggingTest(unittest.TestCase):
@@ -80,11 +93,16 @@ class LoggingTest(unittest.TestCase):
         df = sc.createDataFrame(data, columns)
         t.transform(df)
         t.fit(df)
+        t.test_feature_name()
         t.test_custom_function(df)
         try:
             t.test_throw()
         except Exception as e:
             assert f"{e}" == "test exception"
+        try:
+            t.test_custom_function_w_collision(df)
+        except Exception as e:
+            assert f"{e}" == "Shared keys found in custom logger dictionary: {'className'}"
 
 
 if __name__ == "__main__":

--- a/core/src/test/python/synapsemltest/core/test_logging.py
+++ b/core/src/test/python/synapsemltest/core/test_logging.py
@@ -50,6 +50,13 @@ class NoInheritTransformer():
     def test_throw(self):
         raise Exception("test exception")
 
+    def custom_logging_function(self, results, *args, **kwargs):
+        return f"Custom Function with arguments {args} returned with {results}"
+
+    @SynapseMLLogger.log_verb_static(custom_log_function=custom_logging_function)
+    def test_custom_function(self, df):
+        return 42
+
 
 class LoggingTest(unittest.TestCase):
     def test_logging_smoke(self):
@@ -65,13 +72,14 @@ class LoggingTest(unittest.TestCase):
             assert f"{e}" == "test exception"
         t.test_feature_name()
 
-    def test_logging_smoke_no_inheritance(self):
+    def test_log_verb_static(self):
         t = NoInheritTransformer()
         data = [("Alice", 25), ("Bob", 30), ("Charlie", 35)]
         columns = ["name", "age"]
         df = sc.createDataFrame(data, columns)
         t.transform(df)
         t.fit(df)
+        t.test_custom_function(df)
         try:
             t.test_throw()
         except Exception as e:

--- a/core/src/test/python/synapsemltest/core/test_logging.py
+++ b/core/src/test/python/synapsemltest/core/test_logging.py
@@ -51,7 +51,8 @@ class NoInheritTransformer():
         raise Exception("test exception")
 
     def custom_logging_function(self, results, *args, **kwargs):
-        return f"Custom Function with arguments {args} returned with {results}"
+        return {"args": f"Arguments: {args}",
+                "result": str(results)}
 
     @SynapseMLLogger.log_verb_static(custom_log_function=custom_logging_function)
     def test_custom_function(self, df):


### PR DESCRIPTION
<!-- 🚨 We recommend pull requests be filed from a non-master branch on a repository fork (e.g. <username>:fix-xxx). 🚨 -->

## Related Issues/PRs

<!--
Please reference any related feature requests, issues, or PRs here. For example, `#123`. To automatically close the referenced items when this PR is merged, please use a closing keyword (close, fix, or resolve). For example, `Close #123`. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue for more information.
-->
#xxx

## What changes are proposed in this pull request?

Allow users to pass a custom logging function in the decorator to create info to log using the args and results from the function that is being decorated. 

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [ ] I have written tests (not required for typo or doc fix) and confirmed the proposed feature/bug-fix/change works.

## Does this PR change any dependencies?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure the dependencies are resolved correctly, and list changes here.

## Does this PR add a new feature? If so, have you added samples on website?

- [ ] No. You can skip this section.
- [ ] Yes. Make sure you have added samples following below steps.

1. Find the corresponding markdown file for your new feature in `website/docs/documentation` folder.
   Make sure you choose the correct class `estimators/transformers` and namespace.
2. Follow the pattern in markdown file and add another section for your new API, including pyspark, scala (and .NET potentially) samples.
3. Make sure the `DocTable` points to correct API link.
4. Navigate to website folder, and run `yarn run start` to make sure the website renders correctly.
5. Don't forget to add `<!--pytest-codeblocks:cont-->` before each python code blocks to enable auto-tests for python samples.
6. Make sure the `WebsiteSamplesTests` job pass in the pipeline.
